### PR TITLE
Enhance event filtering capabilities in configuration

### DIFF
--- a/helm/kubernetes-event-exporter/README.md
+++ b/helm/kubernetes-event-exporter/README.md
@@ -147,6 +147,8 @@ existingConfigMap: "my-event-exporter-config"
 | `aws.secretKeys.secretAccessKey` | See values.yaml | `"AWS_SECRET_ACCESS_KEY"` |
 | `aws.secretKeys.sessionToken` | See values.yaml | `"AWS_SESSION_TOKEN"` |
 | `cluster.name` | The name of the service account to use. | `"event-exporter-demo"` |
+| `config.excludeComponents` | Server-side filtering: events matching these components are never sent by the kube-apiserver to the watcher. Maps to a `source!=X` field selector for each entry. Useful to silence noisy controllers. Example: ["persistentvolume-controller", "attachdetach-controller"]  NOTE: when this list is empty AND `fieldSelector` below is empty, the binary applies a built-in default of `source!=persistentvolume-controller` (see DefaultFieldSelector in pkg/exporter/config.go). To opt out entirely, set `fieldSelector` to any non-empty value (e.g. "metadata.namespace!=__none__"). | `[]` |
+| `config.fieldSelector` | Raw field selector escape hatch. If set, takes precedence over excludeComponents AND disables the binary's built-in default. See: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/ Selectable fields on core/v1 Events include: involvedObject.kind, involvedObject.namespace, involvedObject.name, reason, source, type. | `""` |
 | `config.kubeBurst` | See values.yaml | `500` |
 | `config.kubeQPS` | See values.yaml | `100` |
 | `config.logFormat` | See values.yaml | `"json"` |
@@ -178,7 +180,7 @@ existingConfigMap: "my-event-exporter-config"
 | `receivers.stdout.deDot` | See values.yaml | `true` |
 | `receivers.stdout.enabled` | Enable AWS EventBridge integration | `true` |
 | `replicaCount` | Default values for kubernetes-event-exporter. | `1` |
-| `routes` | Route configuration | See values.yaml |
+| `routes` | Route configuration.  Each entry under `routes` becomes a sub-route. Every key inside `match` or `drop` is passed through verbatim to the exporter, so you can use any field supported by Rule (reason, kind, namespace, type, component, labels, etc.). All values are evaluated as regex.  Default allowlist below matches the set of event reasons consumed by the controlplane job analyzer. Anything not matching is dropped by the route. Edit `reason` (or remove it) to receive more/different events. | See values.yaml |
 | `securityContext.allowPrivilegeEscalation` | See values.yaml | `false` |
 | `securityContext.capabilities.drop` | See values.yaml | See values.yaml |
 | `serviceAccount.annotations` | Annotations to add to the service account | `{}` |

--- a/helm/kubernetes-event-exporter/README.md
+++ b/helm/kubernetes-event-exporter/README.md
@@ -155,6 +155,7 @@ existingConfigMap: "my-event-exporter-config"
 | `config.logLevel` | See values.yaml | `"debug"` |
 | `config.maxEventAgeSeconds` | See values.yaml | `60` |
 | `config.metricsNamePrefix` | See values.yaml | `"event_exporter_"` |
+| `config.reasonAllowlist` | reasonAllowlist is a regex evaluated client-side against event.Reason before any route processing. Events whose reason does not match are dropped before they reach any receiver. When empty, the binary applies its built-in default (DefaultReasonAllowlist in pkg/exporter/config.go) which matches the reasons consumed by the controlplane job analyzer. Set to ".*" to disable. | `""` |
 | `eventbridge.detailType` | See values.yaml | `"CloudEvent"` |
 | `eventbridge.enabled` | Enable AWS EventBridge integration | `true` |
 | `eventbridge.eventBusName` | See values.yaml | `"default"` |

--- a/helm/kubernetes-event-exporter/templates/configmap.yaml
+++ b/helm/kubernetes-event-exporter/templates/configmap.yaml
@@ -21,14 +21,34 @@ data:
     {{- if .Values.config.metricsNamePrefix }}
     metricsNamePrefix: {{ .Values.config.metricsNamePrefix }}
     {{- end }}
-    
+    {{- $fs := .Values.config.fieldSelector }}
+    {{- if and (not $fs) .Values.config.excludeComponents }}
+      {{- $parts := list }}
+      {{- range .Values.config.excludeComponents }}
+        {{- $parts = append $parts (printf "source!=%s" .) }}
+      {{- end }}
+      {{- $fs = join "," $parts }}
+    {{- end }}
+    {{- if $fs }}
+    fieldSelector: {{ $fs | quote }}
+    {{- end }}
+
     route:
+      {{- if .Values.config.drop }}
+      drop:
+        {{- toYaml .Values.config.drop | nindent 8 }}
+      {{- end }}
       routes:
         {{- range .Values.routes }}
+        {{- if .drop }}
+        - drop:
+            {{- toYaml .drop | nindent 12 }}
+          match:
+            {{- toYaml .match | nindent 12 }}
+        {{- else }}
         - match:
-            {{- range .match }}
-            - receiver: {{ .receiver | quote }}
-            {{- end }}
+            {{- toYaml .match | nindent 12 }}
+        {{- end }}
         {{- end }}
     
     receivers:

--- a/helm/kubernetes-event-exporter/templates/configmap.yaml
+++ b/helm/kubernetes-event-exporter/templates/configmap.yaml
@@ -32,6 +32,9 @@ data:
     {{- if $fs }}
     fieldSelector: {{ $fs | quote }}
     {{- end }}
+    {{- if .Values.config.reasonAllowlist }}
+    reasonAllowlist: {{ .Values.config.reasonAllowlist | quote }}
+    {{- end }}
 
     route:
       {{- if .Values.config.drop }}

--- a/helm/kubernetes-event-exporter/values.yaml
+++ b/helm/kubernetes-event-exporter/values.yaml
@@ -84,6 +84,12 @@ config:
   # Selectable fields on core/v1 Events include: involvedObject.kind,
   # involvedObject.namespace, involvedObject.name, reason, source, type.
   fieldSelector: ""
+  # reasonAllowlist is a regex evaluated client-side against event.Reason before
+  # any route processing. Events whose reason does not match are dropped before
+  # they reach any receiver. When empty, the binary applies its built-in default
+  # (DefaultReasonAllowlist in pkg/exporter/config.go) which matches the reasons
+  # consumed by the controlplane job analyzer. Set to ".*" to disable.
+  reasonAllowlist: ""
 
 # AWS Configuration for EventBridge
 aws:

--- a/helm/kubernetes-event-exporter/values.yaml
+++ b/helm/kubernetes-event-exporter/values.yaml
@@ -68,6 +68,22 @@ config:
   kubeQPS: 100
   kubeBurst: 500
   metricsNamePrefix: event_exporter_
+  # Server-side filtering: events matching these components are never sent
+  # by the kube-apiserver to the watcher. Maps to a `source!=X` field selector
+  # for each entry. Useful to silence noisy controllers.
+  # Example: ["persistentvolume-controller", "attachdetach-controller"]
+  #
+  # NOTE: when this list is empty AND `fieldSelector` below is empty, the
+  # binary applies a built-in default of `source!=persistentvolume-controller`
+  # (see DefaultFieldSelector in pkg/exporter/config.go). To opt out entirely,
+  # set `fieldSelector` to any non-empty value (e.g. "metadata.namespace!=__none__").
+  excludeComponents: []
+  # Raw field selector escape hatch. If set, takes precedence over
+  # excludeComponents AND disables the binary's built-in default. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+  # Selectable fields on core/v1 Events include: involvedObject.kind,
+  # involvedObject.namespace, involvedObject.name, reason, source, type.
+  fieldSelector: ""
 
 # AWS Configuration for EventBridge
 aws:
@@ -110,12 +126,23 @@ eventbridge:
 cluster:
   name: "event-exporter-demo"
 
-# Route configuration
+# Route configuration.
+#
+# Each entry under `routes` becomes a sub-route. Every key inside `match` or
+# `drop` is passed through verbatim to the exporter, so you can use any field
+# supported by Rule (reason, kind, namespace, type, component, labels, etc.).
+# All values are evaluated as regex.
+#
+# Default allowlist below matches the set of event reasons consumed by the
+# controlplane job analyzer. Anything not matching is dropped by the route.
+# Edit `reason` (or remove it) to receive more/different events.
 routes:
   - match:
-      - receiver: "eventbridge"
+      - reason: "^(Scheduled|Pulling|Pulled|ProviderCreateSuccess|Created|Running|Succeeded|Completed|Failed|BackOff|FailedMount|FailedAttachVolume|Killing|Preempting|Terminated|OOMKilled|FailedScheduling|Error)$"
+        receiver: "eventbridge"
   - match:
-      - receiver: "stdout"
+      - reason: "^(Scheduled|Pulling|Pulled|ProviderCreateSuccess|Created|Running|Succeeded|Completed|Failed|BackOff|FailedMount|FailedAttachVolume|Killing|Preempting|Terminated|OOMKilled|FailedScheduling|Error)$"
+        receiver: "stdout"
 
 # Receiver configurations
 receivers:

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 		}
 	}
 
-	w := kube.NewEventWatcher(kubecfg, cfg.Namespace, cfg.MaxEventAgeSeconds, metricsStore, onEvent, cfg.OmitLookup, cfg.CacheSize)
+	w := kube.NewEventWatcher(kubecfg, cfg.Namespace, cfg.MaxEventAgeSeconds, metricsStore, onEvent, cfg.OmitLookup, cfg.CacheSize, cfg.FieldSelector)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -15,11 +15,16 @@ import (
 const (
 	DefaultCacheSize = 1024
 	// DefaultFieldSelector is applied when Config.FieldSelector is empty.
-	// persistentvolume-controller is almost always the noisiest source on
-	// real clusters and is filtered out by default. Users that genuinely
-	// want those events can override by setting FieldSelector explicitly
+	// These sources/reasons are by far the noisiest on real clusters and
+	// are filtered out server-side by default. Users that genuinely want
+	// those events can override by setting FieldSelector explicitly
 	// (any non-empty value disables this default).
-	DefaultFieldSelector = "source!=persistentvolume-controller"
+	DefaultFieldSelector = "source!=persistentvolume-controller,reason!=ProviderUpdateSuccess,reason!=ProviderDeleteSuccess"
+	// DefaultReasonAllowlist drops any event whose reason does not match
+	// this regex before it reaches the user's route engine. The set matches
+	// the reasons consumed by the controlplane job analyzer. To disable,
+	// set Config.ReasonAllowlist to ".*" (or any always-true regex).
+	DefaultReasonAllowlist = "^(Scheduled|Pulling|Pulled|ProviderCreateSuccess|Created|Running|Succeeded|Completed|Failed|BackOff|FailedMount|FailedAttachVolume|Killing|Preempting|Terminated|OOMKilled|FailedScheduling|Error)$"
 )
 
 // Config allows configuration
@@ -47,6 +52,10 @@ type Config struct {
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
 	// When empty, defaults to DefaultFieldSelector. Set any non-empty value to opt out.
 	FieldSelector string `yaml:"fieldSelector,omitempty"`
+	// ReasonAllowlist is a regex evaluated against event.Reason before any route
+	// processing. Events that do not match are dropped (and never reach a receiver).
+	// When empty, defaults to DefaultReasonAllowlist. To disable, set to ".*".
+	ReasonAllowlist string `yaml:"reasonAllowlist,omitempty"`
 }
 
 func (c *Config) SetDefaults() {
@@ -58,6 +67,11 @@ func (c *Config) SetDefaults() {
 	if c.FieldSelector == "" {
 		c.FieldSelector = DefaultFieldSelector
 		log.Info().Str("fieldSelector", c.FieldSelector).Msg("setting config.fieldSelector (default)")
+	}
+
+	if c.ReasonAllowlist == "" {
+		c.ReasonAllowlist = DefaultReasonAllowlist
+		log.Info().Str("reasonAllowlist", c.ReasonAllowlist).Msg("setting config.reasonAllowlist (default)")
 	}
 
 	if c.KubeBurst == 0 {

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -14,6 +14,12 @@ import (
 
 const (
 	DefaultCacheSize = 1024
+	// DefaultFieldSelector is applied when Config.FieldSelector is empty.
+	// persistentvolume-controller is almost always the noisiest source on
+	// real clusters and is filtered out by default. Users that genuinely
+	// want those events can override by setting FieldSelector explicitly
+	// (any non-empty value disables this default).
+	DefaultFieldSelector = "source!=persistentvolume-controller"
 )
 
 // Config allows configuration
@@ -35,12 +41,23 @@ type Config struct {
 	MetricsNamePrefix  string                    `yaml:"metricsNamePrefix,omitempty"`
 	OmitLookup         bool                      `yaml:"omitLookup,omitempty"`
 	CacheSize          int                       `yaml:"cacheSize,omitempty"`
+	// FieldSelector is passed verbatim to the Events informer ListOptions, so the
+	// apiserver filters events server-side and the exporter never receives them.
+	// Example: "source!=persistentvolume-controller,source!=attachdetach-controller".
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+	// When empty, defaults to DefaultFieldSelector. Set any non-empty value to opt out.
+	FieldSelector string `yaml:"fieldSelector,omitempty"`
 }
 
 func (c *Config) SetDefaults() {
 	if c.CacheSize == 0 {
 		c.CacheSize = DefaultCacheSize
 		log.Debug().Msg("setting config.cacheSize=1024 (default)")
+	}
+
+	if c.FieldSelector == "" {
+		c.FieldSelector = DefaultFieldSelector
+		log.Info().Str("fieldSelector", c.FieldSelector).Msg("setting config.fieldSelector (default)")
 	}
 
 	if c.KubeBurst == 0 {

--- a/pkg/exporter/engine.go
+++ b/pkg/exporter/engine.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"reflect"
+	"regexp"
 
 	"github.com/blaxel-ai/kubernetes-event-exporter/pkg/kube"
 	"github.com/rs/zerolog/log"
@@ -9,8 +10,9 @@ import (
 
 // Engine is responsible for initializing the receivers from sinks
 type Engine struct {
-	Route    Route
-	Registry ReceiverRegistry
+	Route           Route
+	Registry        ReceiverRegistry
+	ReasonAllowlist *regexp.Regexp
 }
 
 func NewEngine(config *Config, registry ReceiverRegistry) *Engine {
@@ -28,14 +30,28 @@ func NewEngine(config *Config, registry ReceiverRegistry) *Engine {
 		registry.Register(v.Name, sink)
 	}
 
+	var allowlist *regexp.Regexp
+	if config.ReasonAllowlist != "" {
+		compiled, err := regexp.Compile(config.ReasonAllowlist)
+		if err != nil {
+			log.Fatal().Err(err).Str("reasonAllowlist", config.ReasonAllowlist).Msg("invalid reasonAllowlist regex")
+		}
+		allowlist = compiled
+	}
+
 	return &Engine{
-		Route:    config.Route,
-		Registry: registry,
+		Route:           config.Route,
+		Registry:        registry,
+		ReasonAllowlist: allowlist,
 	}
 }
 
 // OnEvent does not care whether event is add or update. Prior filtering should be done in the controller/watcher
 func (e *Engine) OnEvent(event *kube.EnhancedEvent) {
+	if e.ReasonAllowlist != nil && !e.ReasonAllowlist.MatchString(event.Reason) {
+		log.Debug().Str("reason", event.Reason).Msg("event dropped by reasonAllowlist")
+		return
+	}
 	e.Route.ProcessEvent(event, e.Registry)
 }
 

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -32,9 +33,19 @@ type EventWatcher struct {
 	clientset           *kubernetes.Clientset
 }
 
-func NewEventWatcher(config *rest.Config, namespace string, MaxEventAgeSeconds int64, metricsStore *metrics.Store, fn EventHandler, omitLookup bool, cacheSize int) *EventWatcher {
+func NewEventWatcher(config *rest.Config, namespace string, MaxEventAgeSeconds int64, metricsStore *metrics.Store, fn EventHandler, omitLookup bool, cacheSize int, fieldSelector string) *EventWatcher {
 	clientset := kubernetes.NewForConfigOrDie(config)
-	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithNamespace(namespace))
+
+	factoryOpts := []informers.SharedInformerOption{
+		informers.WithNamespace(namespace),
+	}
+	if fieldSelector != "" {
+		log.Info().Str("fieldSelector", fieldSelector).Msg("applying server-side field selector to Events watch")
+		factoryOpts = append(factoryOpts, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fieldSelector
+		}))
+	}
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, factoryOpts...)
 	informer := factory.Core().V1().Events().Informer()
 
 	watcher := &EventWatcher{


### PR DESCRIPTION
- Added support for server-side event filtering through a new `fieldSelector` option in the configuration.
- Introduced `excludeComponents` to specify components that should be filtered out from event watching.
- Updated the Helm chart's `values.yaml` to include new configuration options and improved documentation for clarity.
- Modified the `EventWatcher` to apply the field selector when initializing the event informer.